### PR TITLE
Enable build invoking in UI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 
 jobs:


### PR DESCRIPTION
We want to be able to run builds on-demand via the UI. This puts the button in github jobs